### PR TITLE
Fix: Organize root directory SRT files under projects/

### DIFF
--- a/.claude/agents/content-extractor/agent.md
+++ b/.claude/agents/content-extractor/agent.md
@@ -221,19 +221,19 @@ Your work is considered complete if and only if:
 
 ## Language-Specific Output
 
-根据 standardized configuration 中的 `language` 参数使用对应语言：
+Format output according to the `language` parameter from the standardized configuration:
 
-### 英语 (language: "en")
+### English (language: "en")
 
-- 使用 `labels.en.anki.*` 标签（如 `<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>IELTS Score</b>`）
-- 输出内容为英语
+- Use `labels.en.anki.*` labels (e.g., `<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>IELTS Score</b>`)
+- Output content in English
 
-### 中文 (language: "zh")
+### Chinese (language: "zh")
 
-- 使用 `labels.zh.anki.*` 标签（如 `<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>IELTS评分</b>`）
-- 输出内容为中文
+- Use `labels.zh.anki.*` labels (e.g., `<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>IELTS评分</b>`)
+- Output content in Chinese
 
-**重要**：以下 Anki CSV 示例使用英文标签作为参考。实际生成时，请根据 `language` 参数动态替换为对应语言的标签。
+**Note**: The Anki CSV examples below use English labels as reference. When generating, dynamically replace with labels corresponding to the `language` parameter.
 
 ## Anki CSV Output Format
 
@@ -264,4 +264,4 @@ Front	Back	Tags
 | `key-point-*` | ❌ No | - |
 | `collocation-*` | ❌ No | - |
 
-**IPA Format**: `<b>IPA</b>: /音标内容/<br>` (English) or `<b>音标</b>: /音标内容/<br>` (Chinese), placed at the very beginning of Back field
+**IPA Format**: `<b>IPA</b>: /.../<br>` (English) or `<b>音标</b>: /.../<br>` (Chinese), placed at the very beginning of Back field

--- a/.claude/agents/content-extractor/agent.md
+++ b/.claude/agents/content-extractor/agent.md
@@ -221,7 +221,19 @@ Your work is considered complete if and only if:
 
 ## Language-Specific Output
 
-The agent uses labels from the input context to format output according to the target language.
+根据 standardized configuration 中的 `language` 参数使用对应语言：
+
+### 英语 (language: "en")
+
+- 使用 `labels.en.anki.*` 标签（如 `<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>IELTS Score</b>`）
+- 输出内容为英语
+
+### 中文 (language: "zh")
+
+- 使用 `labels.zh.anki.*` 标签（如 `<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>IELTS评分</b>`）
+- 输出内容为中文
+
+**重要**：以下 Anki CSV 示例使用英文标签作为参考。实际生成时，请根据 `language` 参数动态替换为对应语言的标签。
 
 ## Anki CSV Output Format
 
@@ -235,10 +247,10 @@ When generating `anki-deck.csv`, follow the following format specifications (tab
 #tags:true
 
 Front	Back	Tags
-"comprehensive"	"<b>音标</b>: /ˌkɒmprɪˈhensɪv/<br><b>中文</b>: 全面的<br><b>词性</b>: adj<br><b>搭配</b>: comprehensive study / analysis<br><b>替换</b>: thorough, complete<br><b>IELTS评分</b>: LR 7.0+"	"vocabulary academic priority-2"
-"account for"	"<b>中文</b>: 是……的原因；占（比例）<br><b>例句</b>: Human activities <b>account for</b> most of the global warming.<br><b>IELTS应用</b>: Task 2解释原因必备"	"verb-phrase priority-1"
-"It is widely argued that..."	"<b>中文</b>: 人们普遍认为……<br><b>用法</b>: 引出普遍观点，避免主观性<br><b>IELTS应用</b>: Task 2 引出观点"	"expression priority-1 academic"
-"climate change"	"<b>音标</b>: /ˈklaɪmət ʃeɪndʒ/<br><b>中文</b>: 气候变化<br><b>搭配</b>: address / tackle climate change<br><b>IELTS应用</b>: 环境类话题核心词汇"	"topic environment core"
+"comprehensive"	"<b>IPA</b>: /ˌkɒmprɪˈhensɪv/<br><b>Definition</b>: comprehensive<br><b>POS</b>: adj<br><b>Collocation</b>: comprehensive study / analysis<br><b>Synonyms</b>: thorough, complete<br><b>IELTS Score</b>: LR 7.0+"	"vocabulary academic priority-2"
+"account for"	"<b>Definition</b>: to cause; to form the bulk of<br><b>Example</b>: Human activities <b>account for</b> most of the global warming.<br><b>IELTS Application</b>: Task 2解释原因必备"	"verb-phrase priority-1"
+"It is widely argued that..."	"<b>Definition</b>: people generally believe that...<br><b>Usage</b>: 引出普遍观点，避免主观性<br><b>IELTS Application</b>: Task 2 引出观点"	"expression priority-1 academic"
+"climate change"	"<b>IPA</b>: /ˈklaɪmət ʃeɪndʒ/<br><b>Definition</b>: climate change<br><b>Collocation</b>: address / tackle climate change<br><b>IELTS Application</b>: 环境类话题核心词汇"	"topic environment core"
 ```
 
 ### IPA Transcription Rules
@@ -252,4 +264,4 @@ Front	Back	Tags
 | `key-point-*` | ❌ No | - |
 | `collocation-*` | ❌ No | - |
 
-**IPA Format**: `<b>音标</b>: /音标内容/<br>` (placed at the very beginning of Back field)
+**IPA Format**: `<b>IPA</b>: /音标内容/<br>` (English) or `<b>音标</b>: /音标内容/<br>` (Chinese), placed at the very beginning of Back field

--- a/.claude/config/labels.json
+++ b/.claude/config/labels.json
@@ -1,5 +1,16 @@
 {
   "en": {
+    "anki": {
+      "label_ipa": "<b>IPA</b>",
+      "label_chinese": "<b>Definition</b>",
+      "label_pos": "<b>POS</b>",
+      "label_collocation": "<b>Collocation</b>",
+      "label_replacement": "<b>Synonyms</b>",
+      "label_example": "<b>Example</b>",
+      "label_ielts": "<b>IELTS Score</b>",
+      "label_application": "<b>IELTS Application</b>",
+      "label_usage": "<b>Usage</b>"
+    },
     "vocabulary": {
       "label_ipa": "IPA",
       "label_meaning": "Meaning",
@@ -30,6 +41,17 @@
     }
   },
   "zh": {
+    "anki": {
+      "label_ipa": "<b>音标</b>",
+      "label_chinese": "<b>中文</b>",
+      "label_pos": "<b>词性</b>",
+      "label_collocation": "<b>搭配</b>",
+      "label_replacement": "<b>替换</b>",
+      "label_example": "<b>例句</b>",
+      "label_ielts": "<b>IELTS评分</b>",
+      "label_application": "<b>IELTS应用</b>",
+      "label_usage": "<b>用法</b>"
+    },
     "vocabulary": {
       "label_ipa": "国际音标",
       "label_meaning": "释义",

--- a/.claude/skills/extract-subtitle/SKILL.md
+++ b/.claude/skills/extract-subtitle/SKILL.md
@@ -27,7 +27,29 @@ description: 从视频字幕文件自动提取雅思学习材料 (支持 .srt, .
 
 确认文件存在且格式支持。
 
-### 步骤 2.5: 参数标准化 [NEW]
+### 步骤 2.2: 目录组织检查 [NEW]
+
+检测字幕文件位置，确保学习材料统一组织在 `projects/` 目录下：
+
+**检查逻辑**：
+1. 判断字幕文件父目录是否为项目根目录（不是 `projects/` 的子目录）
+2. 如果是根目录字幕文件：
+   - 从文件名生成项目名称（简化文件名，最多 12 个单词，Title Case）
+   - 创建 `projects/[项目名称]/` 目录
+   - 将字幕文件移动到项目目录
+   - 设置输出路径为 `projects/[项目名称]/learning-materials/`
+3. 如果已在 `projects/` 子目录，使用现有目录结构
+
+**项目命名规则**（简化文件名）：
+- 直接从 SRT 文件名提取
+- 移除文件扩展名 (.srt)
+- 清理格式：移除特殊符号，统一为 Title Case
+- 限制最多 12 个单词（超出则截取前 12 个）
+- 示例：
+  - `"The Data movie.srt"` → `"The Data Movie"`
+  - `"In The Future, Killers Dispose of Bodies By Sending Them Back in Time.srt"` → `"In The Future Killers Dispose"`
+
+### 步骤 2.5: 参数标准化
 
 使用 `param-middleware` SubAgent 处理参数：
 - 将原始参数转换为标准配置对象
@@ -75,17 +97,21 @@ description: 从视频字幕文件自动提取雅思学习材料 (支持 .srt, .
 #tags:true
 
 Front	Back	Tags
-"comprehensive"	"<b>音标</b>: /ˌkɒmprɪˈhensɪv/<br><b>中文</b>: 全面的<br><b>词性</b>: adj<br><b>搭配</b>: ...<br><b>IELTS评分</b>: LR 7.0+"	"vocabulary academic priority-2"
-"account for"	"<b>中文</b>: 是……的原因<br><b>例句</b>: ...<br><b>IELTS应用</b>: ..."	"verb-phrase priority-1"
+"comprehensive"	"<b>IPA</b>: /ˌkɒmprɪˈhensɪv/<br><b>Definition</b>: comprehensive<br><b>POS</b>: adj<br><b>Collocation</b>: ...<br><b>IELTS Score</b>: LR 7.0+"	"vocabulary academic priority-2"
+"account for"	"<b>Definition</b>: to cause; to form the bulk of<br><b>Example</b>: ...<br><b>IELTS Application</b>: ..."	"verb-phrase priority-1"
 ```
 
+**标签说明**：标签根据 `language` 参数使用对应语言版本（见 `.claude/config/labels.json`）
+- 英文模式：`<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>Collocation</b>`, `<b>IELTS Score</b>`, `<b>IELTS Application</b>`
+- 中文模式：`<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>搭配</b>`, `<b>IELTS评分</b>`, `<b>IELTS应用</b>`
+
 **音标规则**:
-- `vocabulary-*` 和 `topic-*` 标签的卡片 → **添加音标**，格式 `<b>音标</b>: /音标/<br>`，置于 Back 字段最前
+- `vocabulary-*` 和 `topic-*` 标签的卡片 → **添加音标**，格式 `<b>IPA</b>: /音标/<br>`（英文）或 `<b>音标</b>: /音标/<br>`（中文），置于 Back 字段最前
 - `verb-phrase-*`, `expression-*`, `key-point-*`, `collocation-*` → **不添加音标**
 
 ### 步骤 7: 保存文件
 
-将结果保存到字幕文件同目录下的 `learning-materials/` 文件夹。
+将结果保存到步骤 2.2 确定的输出路径下的 `learning-materials/` 文件夹。
 
 **如果提供了 `video_url` 参数**，额外生成 `video-source.md`：
 


### PR DESCRIPTION
## Summary

Fixes #1 and #2 - Two improvements to the extract-subtitle skill:

### Issue #1: Root directory SRT files not organized under projects/

Root directory SRT files are now automatically organized under `projects/` directory with semantic project names.

**Changes**:
- **SKILL.md**: Added step 2.2 - Directory Organization Check
  - Detects when SRT files are in project root directory
  - Generates semantic project names from filename (max 12 words, Title Case)
  - Creates `projects/[project-name]/` directory
  - Moves SRT file to project directory
  - Sets output path to `projects/[project-name]/learning-materials/`

**Examples**:
- `"The Data movie.srt"` → `"The Data Movie"`
- `"In The Future, Killers Dispose..."` → `"In The Future Killers Dispose"`

---

### Issue #2: Language parameter ignored, content always in Chinese

Language parameter is now properly respected. Default output is English when `-l chinese` is not specified.

**Root Cause**: Anki CSV format examples used hardcoded Chinese labels. AI models follow prompt examples, which overrode the `language: "en"` parameter.

**Changes**:
1. **labels.json**: Added `anki` label configuration for English and Chinese
2. **SKILL.md**: Updated Anki CSV format with English label examples and dynamic label note
3. **content-extractor/agent.md**: Updated Language-Specific Output section with explicit instructions

---

## Testing

### Issue #1
1. Place SRT file in project root
2. Run `/extract-subtitle test.srt`
3. Verify project directory created under `projects/`

### Issue #2
1. Run `/extract-subtitle test.srt` → Verify English output
2. Run `/extract-subtitle test.srt -l zh` → Verify Chinese output