### PR TITLE
Fix: Address code review feedback from PR #3

### DIFF
--- a/.claude/agents/content-extractor/agent.md
+++ b/.claude/agents/content-extractor/agent.md
@@ -221,19 +221,19 @@ Your work is considered complete if and only if:
 
 ## Language-Specific Output
 
-根据 standardized configuration 中的 `language` 参数使用对应语言：
+Format output according to the `language` parameter from the standardized configuration:
 
-### 英语 (language: "en")
+### English (language: "en")
 
-- 使用 `labels.en.anki.*` 标签（如 `<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>IELTS Score</b>`）
-- 输出内容为英语
+- Use `labels.en.anki.*` labels (e.g., `<b>IPA</b>`, `<b>Definition</b>`, `<b>POS</b>`, `<b>IELTS Score</b>`)
+- Output content in English
 
-### 中文 (language: "zh")
+### Chinese (language: "zh")
 
-- 使用 `labels.zh.anki.*` 标签（如 `<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>IELTS评分</b>`）
-- 输出内容为中文
+- Use `labels.zh.anki.*` labels (e.g., `<b>音标</b>`, `<b>中文</b>`, `<b>词性</b>`, `<b>IELTS评分</b>`)
+- Output content in Chinese
 
-**重要**：以下 Anki CSV 示例使用英文标签作为参考。实际生成时，请根据 `language` 参数动态替换为对应语言的标签。
+**Note**: The Anki CSV examples below use English labels as reference. When generating, dynamically replace with labels corresponding to the `language` parameter.
 
 ## Anki CSV Output Format
 
@@ -264,4 +264,4 @@ Front	Back	Tags
 | `key-point-*` | ❌ No | - |
 | `collocation-*` | ❌ No | - |
 
-**IPA Format**: `<b>IPA</b>: /音标内容/<br>` (English) or `<b>音标</b>: /音标内容/<br>` (Chinese), placed at the very beginning of Back field
+**IPA Format**: `<b>IPA</b>: /.../<br>` (English) or `<b>音标</b>: /.../<br>` (Chinese), placed at the very beginning of Back field


### PR DESCRIPTION
## Summary

Addresses code review feedback from PR #3:
https://github.com/duanbiao2000/movieExplainer/pull/3#issuecomment-4060141700

## Changes

### 1. Fix IPA format placeholder inconsistency (line 267)

**Before**:
```
**IPA Format**: `<b>IPA</b>: /音标内容/<br>` (English) or `<b>音标</b>: /音标内容/<br>` (Chinese)
```

**After**:
```
**IPA Format**: `<b>IPA</b>: /.../<br>` (English) or `<b>音标</b>: /.../<br>` (Chinese)
```

The placeholder `/音标内容/` is Chinese within an English format specification. Changed to `/.../` for consistency.

### 2. Fix Chinese text in English documentation (lines 224-236)

**Before**:
```markdown
## Language-Specific Output

根据 standardized configuration 中的 `language` 参数使用对应语言：
### 英语 (language: "en")
...
**重要**：以下 Anki CSV 示例使用英文标签作为参考...
```

**After**:
```markdown
## Language-Specific Output

Format output according to the `language` parameter from the standardized configuration:
### English (language: "en")
...
**Note**: The Anki CSV examples below use English labels as reference...
```

This change aligns with commit 4c5d605 which refactored agent.md to English.

## Testing

- Documentation is now consistently in English
- IPA format placeholders use language-neutral `/.../` syntax
- Changes are documentation-only, no functional code affected

## Summary by Sourcery

Align documentation language and IPA placeholder formatting in the content extractor agent specification.

Documentation:
- Translate remaining Chinese sections in the English content extractor agent documentation to English and clarify language-specific output behavior.
- Standardize IPA example placeholders to a language-neutral `/.../` format in the Anki CSV documentation.